### PR TITLE
Change navigation bar to correctly link to F23 pages

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -28,8 +28,8 @@ main_dropdown:
 
 offering_menus:
   -
-    term: W23
-    baseurl: /w23
+    term: F23
+    baseurl: /f23
     items:
     - title: PA
       url: /pa_list/
@@ -61,8 +61,8 @@ offering_menus:
           description: "Q&A Forum"
     - title: Github
       dropdown:
-        - title: ucsb-cs24-w23
-#           url: https://github.com/ucsb-cs24-w23
+        - title: ucsb-cs24-f23
+#           url: https://github.com/ucsb-cs24-f23
 #   -
 #     term: S20
 #     baseurl: /s20


### PR DESCRIPTION
Navbar currently links to the old W23 pages, which could lead students to outdated lab instructions etc.